### PR TITLE
Add a 1.16 progress notice to the Github README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Psst... Sodium for Minecraft 1.16.2 is being worked on, there's just some other architectural improvements and new optimizations in the pipeline. There's no ETA, but hold tight!  
+Psst... Sodium for Minecraft 1.16.3 is being worked on, there's just some other architectural improvements and new optimizations in the pipeline. There's no ETA, but hold tight!  
 
 ![Project icon](https://git-assets.jellysquid.me/hotlink-ok/sodium/icon-rounded-128px.png)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Psst... Sodium for Minecraft 1.16.2 is being worked on, there's just some other architectural improvements and new optimizations in the pipeline. There's no ETA, but hold tight!  
+
 ![Project icon](https://git-assets.jellysquid.me/hotlink-ok/sodium/icon-rounded-128px.png)
 
 # Sodium (for Fabric)


### PR DESCRIPTION
to mirror the CurseForge page. This may reduce the amount of uninformed "1.16.x??" questions.